### PR TITLE
glyph brush

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,3 +306,6 @@ name = "assets_wasm"
 path = "examples/wasm/assets_wasm.rs"
 required-features = ["bevy_winit"]
 
+[[example]]
+name = "text_debug"
+path = "examples/ui/text_debug.rs"

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -48,6 +48,8 @@ pub struct DrawableText<'a> {
 pub struct DrawableText<'a> {
     pub render_resource_bindings: &'a mut RenderResourceBindings,
     pub asset_render_resource_bindings: &'a mut AssetRenderResourceBindings,
+    pub position: Vec3,
+    pub style: &'a TextStyle,
     pub text_vertices: &'a TextVertices,
     pub msaa: &'a Msaa,
 }
@@ -84,6 +86,8 @@ impl<'a> Drawable for DrawableText<'a> {
         // set global bindings
         context.set_bind_groups_from_bindings(draw, &mut [self.render_resource_bindings])?;
 
+        let position = self.position;
+
         for tv in self.text_vertices.borrow() {
             let atlas_render_resource_bindings = self
                 .asset_render_resource_bindings
@@ -96,11 +100,11 @@ impl<'a> Drawable for DrawableText<'a> {
 
             let sprite = TextureAtlasSprite {
                 index: tv.atlas_info.glyph_index,
-                color: Color::WHITE, 
+                color: self.style.color, 
             };
 
             //let transform = Mat4::from_translation(Vec3::new(tv.position.x(), tv.position.y(), 0.));
-            let transform = Mat4::from_translation(Vec3::new(tv.position.x(), tv.position.y(), 0.));
+            let transform = Mat4::from_translation(position + tv.position.extend(0.));
 
             let transform_buffer = context
                 .shared_buffers

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -98,7 +98,6 @@ impl<'a> Drawable for DrawableText<'a> {
                 color: self.style.color,
             };
 
-            //let transform = Mat4::from_translation(Vec3::new(tv.position.x(), tv.position.y(), 0.));
             let transform = Mat4::from_translation(position + tv.position.extend(0.));
 
             let transform_buffer = context

--- a/crates/bevy_text/src/draw.rs
+++ b/crates/bevy_text/src/draw.rs
@@ -1,7 +1,5 @@
-use crate::{glyph_brush::TextVertex, Font, FontAtlasSet, TextVertices};
-use ab_glyph::{Glyph, PxScale, ScaleFont};
-use bevy_asset::{Assets, Handle};
-use bevy_math::{Mat4, Vec2, Vec3};
+use crate::TextVertices;
+use bevy_math::{Mat4, Vec3};
 use bevy_render::{
     color::Color,
     draw::{Draw, DrawContext, DrawError, Drawable},
@@ -93,14 +91,11 @@ impl<'a> Drawable for DrawableText<'a> {
                 .asset_render_resource_bindings
                 .get_mut(&tv.atlas_info.texture_atlas)
                 .unwrap();
-            context.set_bind_groups_from_bindings(
-                draw,
-                &mut [atlas_render_resource_bindings],
-            )?;
+            context.set_bind_groups_from_bindings(draw, &mut [atlas_render_resource_bindings])?;
 
             let sprite = TextureAtlasSprite {
                 index: tv.atlas_info.glyph_index,
-                color: self.style.color, 
+                color: self.style.color,
             };
 
             //let transform = Mat4::from_translation(Vec3::new(tv.position.x(), tv.position.y(), 0.));

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -54,69 +54,69 @@ impl Font {
     }
 
     // adapted from ab_glyph example: https://github.com/alexheretic/ab-glyph/blob/master/dev/examples/image.rs
-    pub fn render_text(
-        &self,
-        text: &str,
-        color: Color,
-        font_size: f32,
-        width: usize,
-        height: usize,
-    ) -> Texture {
-        let scale = PxScale::from(font_size);
+    // pub fn render_text(
+    //     &self,
+    //     text: &str,
+    //     color: Color,
+    //     font_size: f32,
+    //     width: usize,
+    //     height: usize,
+    // ) -> Texture {
+    //     let scale = PxScale::from(font_size);
 
-        let scaled_font = ab_glyph::Font::as_scaled(&self.font, scale);
+    //     let scaled_font = ab_glyph::Font::as_scaled(&self.font, scale);
 
-        let mut glyphs = Vec::new();
-        layout_paragraph(
-            scaled_font,
-            ab_glyph::point(0.0, 0.0),
-            width as f32,
-            text,
-            &mut glyphs,
-        );
+    //     let mut glyphs = Vec::new();
+    //     layout_paragraph(
+    //         scaled_font,
+    //         ab_glyph::point(0.0, 0.0),
+    //         width as f32,
+    //         text,
+    //         &mut glyphs,
+    //     );
 
-        let color_u8 = [
-            (color.r() * 255.0) as u8,
-            (color.g() * 255.0) as u8,
-            (color.b() * 255.0) as u8,
-        ];
+    //     let color_u8 = [
+    //         (color.r() * 255.0) as u8,
+    //         (color.g() * 255.0) as u8,
+    //         (color.b() * 255.0) as u8,
+    //     ];
 
-        // TODO: this offset is a bit hackey
-        let mut alpha = vec![0.0; width * height];
-        for glyph in glyphs {
-            if let Some(outlined) = scaled_font.outline_glyph(glyph) {
-                let bounds = outlined.px_bounds();
-                // Draw the glyph into the image per-pixel by using the draw closure
-                outlined.draw(|x, y, v| {
-                    // Offset the position by the glyph bounding box
-                    // Turn the coverage into an alpha value (blended with any previous)
-                    let offset_x = x as usize + bounds.min.x as usize;
-                    let offset_y = y as usize + bounds.min.y as usize;
-                    if offset_x >= width || offset_y >= height {
-                        return;
-                    }
-                    alpha[offset_y * width + offset_x] = v;
-                });
-            }
-        }
+    //     // TODO: this offset is a bit hackey
+    //     let mut alpha = vec![0.0; width * height];
+    //     for glyph in glyphs {
+    //         if let Some(outlined) = scaled_font.outline_glyph(glyph) {
+    //             let bounds = outlined.px_bounds();
+    //             // Draw the glyph into the image per-pixel by using the draw closure
+    //             outlined.draw(|x, y, v| {
+    //                 // Offset the position by the glyph bounding box
+    //                 // Turn the coverage into an alpha value (blended with any previous)
+    //                 let offset_x = x as usize + bounds.min.x as usize;
+    //                 let offset_y = y as usize + bounds.min.y as usize;
+    //                 if offset_x >= width || offset_y >= height {
+    //                     return;
+    //                 }
+    //                 alpha[offset_y * width + offset_x] = v;
+    //             });
+    //         }
+    //     }
 
-        Texture::new(
-            Vec2::new(width as f32, height as f32),
-            alpha
-                .iter()
-                .map(|a| {
-                    vec![
-                        color_u8[0],
-                        color_u8[1],
-                        color_u8[2],
-                        (color.a() * a * 255.0) as u8,
-                    ]
-                })
-                .flatten()
-                .collect::<Vec<u8>>(),
-            TextureFormat::Rgba8UnormSrgb,
-        )
-    }
+    //     Texture::new(
+    //         Vec2::new(width as f32, height as f32),
+    //         alpha
+    //             .iter()
+    //             .map(|a| {
+    //                 vec![
+    //                     color_u8[0],
+    //                     color_u8[1],
+    //                     color_u8[2],
+    //                     (color.a() * a * 255.0) as u8,
+    //                 ]
+    //             })
+    //             .flatten()
+    //             .collect::<Vec<u8>>(),
+    //         TextureFormat::Rgba8UnormSrgb,
+    //     )
+    // }
 }
 
 fn layout_paragraph<F, SF>(

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -1,5 +1,5 @@
 use crate::{error::TextError, Font, FontAtlas};
-use ab_glyph::{Glyph, GlyphId, Rect};
+use ab_glyph::{Font as _, Glyph, GlyphId, OutlinedGlyph, Rect};
 use bevy_asset::{Assets, Handle};
 use bevy_core::FloatOrd;
 use bevy_math::Vec2;
@@ -45,16 +45,16 @@ impl FontAtlasSet {
 
     pub fn add_glyph_to_atlas(
         &mut self,
-        fonts: &Assets<Font>,
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Texture>,
-        glyph: Glyph,
-    ) -> Result<(GlyphAtlasInfo, Rect, ), TextError> {
-        use ab_glyph::Font as ab_glyph_font;
-        let font = fonts.get(&self.font).ok_or(TextError::NoSuchFont)?;
+        outlined_glyph: OutlinedGlyph,
+    ) -> Result<GlyphAtlasInfo, TextError> {
+        let glyph = outlined_glyph.glyph();
+        let glyph_id = glyph.id;
+        let font_size = glyph.scale.y;
         let font_atlases = self
             .font_atlases
-            .entry(FloatOrd(glyph.scale.y))
+            .entry(FloatOrd(font_size))
             .or_insert_with(|| {
                 vec![FontAtlas::new(
                     textures,
@@ -62,21 +62,7 @@ impl FontAtlasSet {
                     Vec2::new(512.0, 512.0),
                 )]
             });
-        let font_size = glyph.scale.y;
-        let glyph_id = glyph.id;
-        let outline = font.font.outline_glyph(glyph);
-        let (glyph_texture, bounds) = if let Some(outline) = outline {
-            (Font::get_outlined_glyph_texture(outline), outline.px_bounds())
-        } else {
-            (
-                Texture::new(
-                    Vec2::new(1., 1.),
-                    vec![0, 0, 0, 0],
-                    TextureFormat::Rgba8UnormSrgb,
-                ),
-                Rect::default(),
-            )
-        };
+        let glyph_texture = Font::get_outlined_glyph_texture(outlined_glyph);
         let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
             atlas.add_glyph(textures, texture_atlases, glyph_id, &glyph_texture)
         };
@@ -96,7 +82,7 @@ impl FontAtlasSet {
             }
         }
 
-        Ok((self.get_glyph_atlas_info(font_size, glyph_id).unwrap(), bounds))
+        Ok(self.get_glyph_atlas_info(font_size, glyph_id).unwrap())
     }
 
     pub fn get_glyph_atlas_info(

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -1,5 +1,5 @@
 use crate::{error::TextError, Font, FontAtlas};
-use ab_glyph::{Glyph, GlyphId};
+use ab_glyph::{Glyph, GlyphId, Rect};
 use bevy_asset::{Assets, Handle};
 use bevy_core::FloatOrd;
 use bevy_math::Vec2;
@@ -49,7 +49,7 @@ impl FontAtlasSet {
         texture_atlases: &mut Assets<TextureAtlas>,
         textures: &mut Assets<Texture>,
         glyph: Glyph,
-    ) -> Result<GlyphAtlasInfo, TextError> {
+    ) -> Result<(GlyphAtlasInfo, Rect, ), TextError> {
         use ab_glyph::Font as ab_glyph_font;
         let font = fonts.get(&self.font).ok_or(TextError::NoSuchFont)?;
         let font_atlases = self
@@ -65,13 +65,16 @@ impl FontAtlasSet {
         let font_size = glyph.scale.y;
         let glyph_id = glyph.id;
         let outline = font.font.outline_glyph(glyph);
-        let glyph_texture = if let Some(outline) = outline {
-            Font::get_outlined_glyph_texture(outline)
+        let (glyph_texture, bounds) = if let Some(outline) = outline {
+            (Font::get_outlined_glyph_texture(outline), outline.px_bounds())
         } else {
-            Texture::new(
-                Vec2::new(1., 1.),
-                vec![0, 0, 0, 0],
-                TextureFormat::Rgba8UnormSrgb,
+            (
+                Texture::new(
+                    Vec2::new(1., 1.),
+                    vec![0, 0, 0, 0],
+                    TextureFormat::Rgba8UnormSrgb,
+                ),
+                Rect::default(),
             )
         };
         let add_char_to_font_atlas = |atlas: &mut FontAtlas| -> bool {
@@ -93,7 +96,7 @@ impl FontAtlasSet {
             }
         }
 
-        Ok(self.get_glyph_atlas_info(font_size, glyph_id).unwrap())
+        Ok((self.get_glyph_atlas_info(font_size, glyph_id).unwrap(), bounds))
     }
 
     pub fn get_glyph_atlas_info(

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use ab_glyph::FontArc;
+use ab_glyph::{Font as _, FontArc, ScaleFont as _};
 use bevy_asset::{Assets, Handle};
 use bevy_math::{Size, Vec2};
 use bevy_render::prelude::Texture;
@@ -76,33 +76,60 @@ impl GlyphBrush {
         let sq = std::mem::replace(&mut *sq, Vec::new());
         let vertices = sq
             .into_iter()
-            .map(|glyphs| {
+            .map(|section_glyphs| {
                 let mut vertices = Vec::new();
-                for glyph in glyphs {
-                    let handle = &self.handles[glyph.font_id.0];
-                    let handle_font_atlas: Handle<FontAtlasSet> = handle.as_weak();
-                    let font_atlas_set = font_atlas_set_storage
-                        .get_or_insert_with(handle_font_atlas, || {
-                            FontAtlasSet::new(handle.clone())
-                        });
-                    // let position = glyph.glyph.position;
-                    // let position = Vec2::new(position.x + glyph.glyph.scale.x/2., position.y - glyph.glyph.scale.y - glyph.glyph.scale.y /2. );
 
-                    let atlas_info = font_atlas_set
-                        .get_glyph_atlas_info(glyph.glyph.scale.y, glyph.glyph.id)
-                        .map(|gaf| Ok(gaf))
-                        .unwrap_or_else(|| {
-                            font_atlas_set.add_glyph_to_atlas(
-                                fonts,
-                                texture_atlases,
-                                textures,
-                                glyph.glyph,
-                            )
-                        })?;
-                    vertices.push(TextVertex {
-                        position,
-                        atlas_info,
-                    });
+                let mut max_y: f32 = 0.0;
+                for section_glyph in section_glyphs.iter() {
+                    let handle = &self.handles[section_glyph.font_id.0];
+                    let font = fonts.get(handle).ok_or(TextError::NoSuchFont)?;
+                    let glyph = &section_glyph.glyph;
+                    let scaled_font = ab_glyph::Font::as_scaled(&font.font, glyph.scale.y);
+                    // glyph.position.y = baseline
+                    max_y = max_y.max(glyph.position.y - scaled_font.descent());
+                }
+                max_y = max_y.floor();
+
+                for section_glyph in section_glyphs {
+                    let handle = &self.handles[section_glyph.font_id.0];
+                    let font = fonts.get(handle).ok_or(TextError::NoSuchFont)?;
+                    let glyph_id = section_glyph.glyph.id;
+                    let font_size = section_glyph.glyph.scale.y;
+                    if let Some(outlined_glyph) = font.font.outline_glyph(section_glyph.glyph) {
+                        let bounds = outlined_glyph.px_bounds();
+                        let handle_font_atlas: Handle<FontAtlasSet> = handle.as_weak();
+                        let font_atlas_set = font_atlas_set_storage
+                            .get_or_insert_with(handle_font_atlas, || {
+                                FontAtlasSet::new(handle.clone())
+                            });
+
+                        let atlas_info = font_atlas_set
+                            .get_glyph_atlas_info(font_size, glyph_id)
+                            .map(|gaf| Ok(gaf))
+                            .unwrap_or_else(|| {
+                                font_atlas_set.add_glyph_to_atlas(
+                                    texture_atlases,
+                                    textures,
+                                    outlined_glyph,
+                                )
+                            })?;
+
+                        let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
+                        let glyph_rect = texture_atlas.textures[atlas_info.glyph_index as usize];
+                        let glyph_width = glyph_rect.width();
+                        let glyph_height = glyph_rect.height();
+
+                        let x = bounds.min.x + glyph_width / 2.0;
+                        // the 0.5 accounts for odd-numbered heights (bump up by 1 pixel)
+                        // max_y = text block height, and up is negative (whereas for transform, up is positive)
+                        let y = max_y - bounds.max.y + glyph_height / 2.0 + 0.5;
+                        let position = Vec2::new(x, y);
+
+                        vertices.push(TextVertex {
+                            position,
+                            atlas_info,
+                        });
+                    }
                 }
                 Ok(vertices)
             })

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -34,12 +34,12 @@ impl GlyphBrush {
         &self,
         sections: &[S],
         bounds: Size,
-        screen_position: Vec2,
+        // screen_position: Vec2,
     ) -> Result<Vec<SectionGlyph>, TextError> {
         // Todo: handle cache
         let geom = SectionGeometry {
             bounds: (bounds.width, bounds.height),
-            screen_position: (screen_position.x(), screen_position.y()),
+            // screen_position: (screen_position.x(), screen_position.y()),
             ..Default::default()
         };
         let section_glyphs = Layout::default().calculate_glyphs(&self.fonts, &geom, sections);
@@ -50,9 +50,10 @@ impl GlyphBrush {
         &self,
         sections: &[S],
         bounds: Size,
-        screen_position: Vec2,
+        // screen_position: Vec2,
     ) -> Result<(), TextError> {
-        let glyphs = self.compute_glyphs(sections, bounds, screen_position)?;
+        // let glyphs = self.compute_glyphs(sections, bounds, screen_position)?;
+        let glyphs = self.compute_glyphs(sections, bounds)?;
         let mut sq = self
             .section_queue
             .lock()
@@ -84,8 +85,9 @@ impl GlyphBrush {
                         .get_or_insert_with(handle_font_atlas, || {
                             FontAtlasSet::new(handle.clone())
                         });
-                    let position = glyph.glyph.position;
-                    let position = Vec2::new(position.x + glyph.glyph.scale.x/2., position.y - glyph.glyph.scale.y - glyph.glyph.scale.y /2. );
+                    // let position = glyph.glyph.position;
+                    // let position = Vec2::new(position.x + glyph.glyph.scale.x/2., position.y - glyph.glyph.scale.y - glyph.glyph.scale.y /2. );
+
                     let atlas_info = font_atlas_set
                         .get_glyph_atlas_info(glyph.glyph.scale.y, glyph.glyph.id)
                         .map(|gaf| Ok(gaf))

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-use ab_glyph::PxScale;
+use ab_glyph::{PxScale, ScaleFont};
 use bevy_asset::{Assets, Handle};
 use bevy_math::{Size, Vec2};
 use bevy_render::prelude::Texture;
 use bevy_sprite::TextureAtlas;
 
-use glyph_brush_layout::FontId;
+use glyph_brush_layout::{FontId, SectionText};
 
 use crate::{error::TextError, glyph_brush::GlyphBrush, Font, FontAtlasSet, TextVertex};
 
@@ -29,23 +29,26 @@ impl TextPipeline {
         font_handle: Handle<Font>,
         font_storage: &Assets<Font>,
         text: &str,
-        size: f32,
+        scale: f32,
         bounds: Size,
-    ) -> Result<Vec2, TextError> {
+    ) -> Result<Size<f32>, TextError> {
         let font = font_storage
             .get(font_handle.clone())
             .ok_or(TextError::NoSuchFont)?;
+
         let font_id = self.get_or_insert_font_id(font_handle, font);
 
-        let section = glyph_brush_layout::SectionText {
+        let section = SectionText {
             font_id,
-            scale: PxScale::from(size),
+            scale: PxScale::from(scale),
             text,
         };
 
-        let glyphs = self
+        let scaled_font = ab_glyph::Font::as_scaled(&font.font, scale);
+
+        let section_glyphs = self
             .brush
-            .compute_glyphs(&[section], bounds, Vec2::new(0., 0.))?;
+            .compute_glyphs(&[section], bounds)?;
         /*
         self.measure_brush
             .borrow_mut()
@@ -54,8 +57,15 @@ impl TextPipeline {
             */
 
         // todo: calculate total bounds
-
-        todo!()
+        let mut max_x: f32 = 0.0;
+        let mut max_y: f32 = 0.0;
+        for section_glyph in section_glyphs.iter() {
+            // let glyph_bounds = section_glyph.glyph.
+            max_x = max_x.max(section_glyph.glyph.position.x + scaled_font.h_advance(section_glyph.glyph.id));
+            max_y = max_y.max(section_glyph.glyph.position.y - scaled_font.descent());
+        }
+        let size = Size::new(max_x, max_y);
+        Ok(size)
     }
 
     pub fn get_or_insert_font_id(&mut self, handle: Handle<Font>, font: &Font) -> FontId {
@@ -70,27 +80,27 @@ impl TextPipeline {
         font_handle: Handle<Font>,
         font_storage: &Assets<Font>,
         text: &str,
-        size: f32,
+        font_size: f32,
         bounds: Size,
-        screen_position: Vec2,
+        // screen_position: Vec2,
     ) -> Result<(), TextError> {
         let font = font_storage
             .get(font_handle.clone())
             .ok_or(TextError::NoSuchFont)?;
         let font_id = self.get_or_insert_font_id(font_handle, font);
-
-        let section = glyph_brush_layout::SectionText {
+        
+        let section = SectionText {
             font_id,
-            scale: PxScale::from(size),
+            scale: PxScale::from(font_size),
             text,
         };
 
-        self.brush.queue_text(&[section], bounds, screen_position)?;
+        self.brush.queue_text(&[section], bounds)?;
 
         Ok(())
     }
 
-    pub fn draw_queued(
+    pub fn process_queued(
         &self,
         fonts: &Assets<Font>,
         font_atlas_set_storage: &mut Assets<FontAtlasSet>,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use ab_glyph::{PxScale, ScaleFont};
-use bevy_asset::{Assets, Handle};
-use bevy_math::{Size, Vec2};
+use bevy_asset::{Assets, Handle, HandleId};
+use bevy_math::Size;
 use bevy_render::prelude::Texture;
 use bevy_sprite::TextureAtlas;
 
@@ -12,7 +12,7 @@ use crate::{error::TextError, glyph_brush::GlyphBrush, Font, FontAtlasSet, TextV
 
 pub struct TextPipeline {
     pub brush: GlyphBrush,
-    pub map_font_id: HashMap<Handle<Font>, FontId>,
+    pub map_font_id: HashMap<HandleId, FontId>,
 }
 
 impl Default for TextPipeline {
@@ -33,7 +33,7 @@ impl TextPipeline {
         bounds: Size,
     ) -> Result<Size<f32>, TextError> {
         let font = font_storage
-            .get(font_handle.clone())
+            .get(font_handle.id)
             .ok_or(TextError::NoSuchFont)?;
 
         let font_id = self.get_or_insert_font_id(font_handle, font);
@@ -46,32 +46,24 @@ impl TextPipeline {
 
         let scaled_font = ab_glyph::Font::as_scaled(&font.font, scale);
 
-        let section_glyphs = self
-            .brush
-            .compute_glyphs(&[section], bounds)?;
-        /*
-        self.measure_brush
-            .borrow_mut()
-            .glyph_bounds(section)
-            .map(|bounds| (bounds.width().ceil(), bounds.height().ceil()))
-            */
+        let section_glyphs = self.brush.compute_glyphs(&[section], bounds)?;
 
-        // todo: calculate total bounds
         let mut max_x: f32 = 0.0;
         let mut max_y: f32 = 0.0;
         for section_glyph in section_glyphs.iter() {
-            // let glyph_bounds = section_glyph.glyph.
-            max_x = max_x.max(section_glyph.glyph.position.x + scaled_font.h_advance(section_glyph.glyph.id));
-            max_y = max_y.max(section_glyph.glyph.position.y - scaled_font.descent());
+            let glyph = &section_glyph.glyph;
+            max_x = max_x.max(glyph.position.x + scaled_font.h_advance(glyph.id));
+            max_y = max_y.max(glyph.position.y - scaled_font.descent());
         }
         let size = Size::new(max_x, max_y);
         Ok(size)
     }
 
     pub fn get_or_insert_font_id(&mut self, handle: Handle<Font>, font: &Font) -> FontId {
+        let brush = &mut self.brush;
         self.map_font_id
-            .entry(handle.clone())
-            .or_insert(self.brush.add_font(handle.clone(), font.font.clone()))
+            .entry(handle.id)
+            .or_insert_with(|| brush.add_font(handle.clone(), font.font.clone()))
             .clone()
     }
 
@@ -85,10 +77,10 @@ impl TextPipeline {
         // screen_position: Vec2,
     ) -> Result<(), TextError> {
         let font = font_storage
-            .get(font_handle.clone())
+            .get(font_handle.id)
             .ok_or(TextError::NoSuchFont)?;
         let font_id = self.get_or_insert_font_id(font_handle, font);
-        
+
         let section = SectionText {
             font_id,
             scale: PxScale::from(font_size),

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     texture::Texture,
 };
 use bevy_sprite::TextureAtlas;
-use bevy_text::{DrawableText, Font, FontAtlasSet, TextPipeline, TextStyle, TextVertex, TextVertices};
+use bevy_text::{DrawableText, Font, FontAtlasSet, TextPipeline, TextStyle, TextVertices};
 use bevy_transform::{components::Transform, prelude::GlobalTransform};
 use std::collections::HashSet;
 
@@ -109,10 +109,9 @@ pub fn draw_text_system(
     mut asset_render_resource_bindings: ResMut<AssetRenderResourceBindings>,
     mut query: Query<(&mut Draw, &Text, &TextVertices, &Node, &GlobalTransform)>,
 ) {
-    
     for (mut draw, text, text_vertices, node, global_transform) in &mut query.iter() {
-            let position = global_transform.translation - (node.size / 2.0).extend(0.0);
-            let mut text_drawer = DrawableText {
+        let position = global_transform.translation - (node.size / 2.0).extend(0.0);
+        let mut text_drawer = DrawableText {
             render_resource_bindings: &mut render_resource_bindings,
             asset_render_resource_bindings: &mut asset_render_resource_bindings,
             position,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,6 +1,6 @@
 use crate::{CalculatedSize, Node, Style, Val};
 use bevy_asset::{Assets, Handle};
-use bevy_ecs::{Changed, Entity, Local, Query, Res, ResMut, Resource};
+use bevy_ecs::{Changed, Entity, Local, Or, Query, Res, ResMut, Resource};
 use bevy_math::{Size, Vec2};
 use bevy_render::{
     draw::{Draw, DrawContext, Drawable},
@@ -31,31 +31,13 @@ pub fn text_system(
     mut font_atlas_sets: ResMut<Assets<FontAtlasSet>>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut changed_text_query: Query<(Entity, Changed<Text>)>,
-    mut changed_style_query: Query<(Entity, Changed<Style>)>,
     mut text_query: Query<(
-        Entity,
-        &Text,
-        &Style,
+        Or<(Changed<Text>, Changed<Style>)>,
         &mut TextVertices,
         &mut CalculatedSize,
     )>,
 ) {
-    let mut entities = HashSet::new();
-
-    for (entity, _) in &mut changed_text_query.iter() {
-        entities.insert(entity);
-    }
-
-    for (entity, _) in &mut changed_style_query.iter() {
-        entities.insert(entity);
-    }
-
-    for (entity, text, style, mut vertices, mut calculated_size) in &mut text_query.iter() {
-        if !entities.contains(&entity) {
-            continue;
-        }
-
+    for ((text, style), mut vertices, mut calculated_size) in &mut text_query.iter() {
         let node_size = Size::new(
             match style.size.width {
                 Val::Auto => f32::MAX,
@@ -71,6 +53,7 @@ pub fn text_system(
             },
         );
 
+        // TODO: add support for text alignment
         if let Err(e) = text_pipeline.queue_text(
             text.font.clone(),
             &fonts,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{CalculatedSize, Node};
+use crate::{CalculatedSize, Node, Style, Val};
 use bevy_asset::{Assets, Handle};
 use bevy_ecs::{Changed, Entity, Local, Query, Res, ResMut, Resource};
 use bevy_math::{Size, Vec2};
@@ -11,6 +11,7 @@ use bevy_render::{
 use bevy_sprite::TextureAtlas;
 use bevy_text::{DrawableText, Font, FontAtlasSet, TextPipeline, TextStyle, TextVertex, TextVertices};
 use bevy_transform::{components::Transform, prelude::GlobalTransform};
+use std::collections::HashSet;
 
 #[derive(Debug, Default)]
 pub struct QueuedText {
@@ -30,28 +31,65 @@ pub fn text_system(
     mut font_atlas_sets: ResMut<Assets<FontAtlasSet>>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut text_pipeline: ResMut<TextPipeline>,
+    mut changed_text_query: Query<(Entity, Changed<Text>)>,
+    mut changed_style_query: Query<(Entity, Changed<Style>)>,
     mut text_query: Query<(
-        Changed<Text>,
+        Entity,
+        &Text,
+        &Style,
         &mut TextVertices,
-        &Node,
-        &Transform,
         &mut CalculatedSize,
     )>,
 ) {
-    for (text, mut vertices, node, trans, mut size) in &mut text_query.iter() {
-        let screen_position = trans.translation;
+    let mut entities = HashSet::new();
+
+    for (entity, _) in &mut changed_text_query.iter() {
+        entities.insert(entity);
+    }
+
+    for (entity, _) in &mut changed_style_query.iter() {
+        entities.insert(entity);
+    }
+
+    for (entity, text, style, mut vertices, mut calculated_size) in &mut text_query.iter() {
+        if !entities.contains(&entity) {
+            continue;
+        }
+
+        let node_size = Size::new(
+            match style.size.width {
+                Val::Auto => f32::MAX,
+                Val::Undefined => f32::MAX,
+                Val::Px(num) => num,
+                Val::Percent(_) => f32::MAX, // TODO: support percentages
+            },
+            match style.size.height {
+                Val::Auto => f32::MAX,
+                Val::Undefined => f32::MAX,
+                Val::Px(num) => num,
+                Val::Percent(_) => f32::MAX, // TODO: support percentages
+            },
+        );
+
         if let Err(e) = text_pipeline.queue_text(
             text.font.clone(),
             &fonts,
             &text.value,
             text.style.font_size,
-            Size::new(500., 500.),
-            Vec2::new(screen_position.x(), screen_position.y()),
+            node_size,
         ) {
             println!("Error when adding text to the queue: {:?}", e);
+        } else if let Ok(new_size) = text_pipeline.measure(
+            text.font.clone(),
+            &fonts,
+            &text.value,
+            text.style.font_size,
+            node_size,
+        ) {
+            calculated_size.size = new_size;
         }
 
-        match text_pipeline.draw_queued(
+        match text_pipeline.process_queued(
             &fonts,
             &mut font_atlas_sets,
             &mut texture_atlases,
@@ -69,15 +107,18 @@ pub fn draw_text_system(
     msaa: Res<Msaa>,
     mut render_resource_bindings: ResMut<RenderResourceBindings>,
     mut asset_render_resource_bindings: ResMut<AssetRenderResourceBindings>,
-    mut query: Query<(&mut Draw, &TextVertices, &GlobalTransform)>,
+    mut query: Query<(&mut Draw, &Text, &TextVertices, &Node, &GlobalTransform)>,
 ) {
     
-    for (mut draw, text_vertices, _) in &mut query.iter() {
-        let mut text_drawer = DrawableText {
+    for (mut draw, text, text_vertices, node, global_transform) in &mut query.iter() {
+            let position = global_transform.translation - (node.size / 2.0).extend(0.0);
+            let mut text_drawer = DrawableText {
             render_resource_bindings: &mut render_resource_bindings,
             asset_render_resource_bindings: &mut asset_render_resource_bindings,
+            position,
             msaa: &msaa,
             text_vertices,
+            style: &text.style,
         };
         text_drawer.draw(&mut draw, &mut context).unwrap();
     }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -1,0 +1,128 @@
+use bevy::prelude::*;
+extern crate rand;
+
+/// This example is for debugging text layout
+fn main() {
+    App::build()
+        .add_default_plugins()
+        .add_startup_system(infotext_system.system())
+        .add_system(change_text_system.system())
+        .run();
+}
+
+struct TextChanges;
+
+fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    commands
+        .spawn(UiCameraComponents::default())
+        .spawn(TextComponents {
+            style: Style {
+                align_self: AlignSelf::FlexEnd,
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    top: Val::Px(5.0),
+                    left: Val::Px(15.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            text: Text {
+                value: "This is\ntext with\nline breaks\nin the top left".to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            },
+            ..Default::default()
+        });
+    commands
+        .spawn(UiCameraComponents::default())
+        .spawn(TextComponents {
+            style: Style {
+                align_self: AlignSelf::FlexEnd,
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    top: Val::Px(5.0),
+                    right: Val::Px(15.0),
+                    ..Default::default()
+                },
+                size: Size {
+                    width: Val::Px(400.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            text: Text {
+                value:
+                    "This is very long text with limited width in the top right and is also pink"
+                        .to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::rgb(0.8, 0.2, 0.7),
+                },
+            },
+            ..Default::default()
+        });
+    commands
+        .spawn(UiCameraComponents::default())
+        .spawn(TextComponents {
+            style: Style {
+                align_self: AlignSelf::FlexEnd,
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    bottom: Val::Px(5.0),
+                    right: Val::Px(15.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            text: Text {
+                value: "This text changes in the bottom right".to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            },
+            ..Default::default()
+        })
+        .with(TextChanges);
+    commands
+        .spawn(UiCameraComponents::default())
+        .spawn(TextComponents {
+            style: Style {
+                align_self: AlignSelf::FlexEnd,
+                position_type: PositionType::Absolute,
+                position: Rect {
+                    bottom: Val::Px(5.0),
+                    left: Val::Px(15.0),
+                    ..Default::default()
+                },
+                size: Size {
+                    width: Val::Px(200.0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            text: Text {
+                value: "This\ntext has\nline breaks and also a set width in the bottom left"
+                    .to_string(),
+                font: font.clone(),
+                style: TextStyle {
+                    font_size: 50.0,
+                    color: Color::WHITE,
+                },
+            },
+            ..Default::default()
+        });
+}
+
+fn change_text_system(mut text: Mut<Text>, _: &TextChanges) {
+    text.value = format!(
+        "This text changes in the bottom right {}",
+        rand::random::<u16>(),
+    );
+}


### PR DESCRIPTION
Use `cargo run --example text_debug` to see what these changes enable.

![image](https://user-images.githubusercontent.com/38416468/97712466-6fcfcb80-1af9-11eb-9573-c7dcf845790e.png)

In brief:

- `text_vertex.position` is now relative to the bottom left corner of its text block, allowing the flexbox system to control its layout
- finish the `TextPipeline::measure()` method to calculate the size of the text block in the `text_system`, allowing the flexbox system to calculate its layout and position
- lift `outline_glyph` from `FontAtlasSet::add_glyph_to_atlas` (and related methods and variables) to outer calling function `GlyphBrush::process_queued`, in order to make use of the `bounds` to calculate the correct position (along with other calculations including `max_y`)
- change key for `text_pipeline.map_font_id` from `Handle<Font>` to `HandleId` which is likely cheaper (`HandleId` is `Copy`, is unique and stable)
- make use of `Style` component for size and positioning
- change `get_or_insert_font_id` to use `.or_insert_with` for lazy evaluation (`.or_insert` was eagerly evaluating, re-adding already-existing fonts every frame)
- use `Or<(Changed<Text>, Changed<Style>)>` query in `text_system`
- add `text_debug` example for development and testing

Unfinished:

- Remove commented-out code
- Remove unused imports

Possible further improvements:

- Some form of caching (note: TextPipeline::glyph_brush should not control where the text is drawn to the screen, only the relative position to its absolute position)
- Text alignment is supported by glyph_brush_layout but currently no provision for it in `TextStyle`, would be very straightforward to implement
- Transform-aware? (scale, rotation, etc.)
- Mixed-style text is supported by glyph_brush_layout (SectionText) but bevy currently doesn't provide an API for this.